### PR TITLE
feat: add the ability to pass parameters to translation strings

### DIFF
--- a/docs/pages/docs/features/translations/index.md
+++ b/docs/pages/docs/features/translations/index.md
@@ -30,6 +30,7 @@ is `en`:
 
 ```ini file:app/lang/my.ini
 hello = "world"
+greeting = "Hello, :name!"
 
 [planet]
 ours = "Earth"
@@ -40,7 +41,7 @@ ours = "Earth"
 In the below case, the `"my.hello"` phrase is going to be loaded from the
 `app/lang/en/my.ini` file.
 
-The `Request` object is used to determine the current client's languge (by 
+The `Request` object is used to determine the current client's language (by 
 default by using the [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)
 header).
 
@@ -60,12 +61,27 @@ readonly class MyClass
 
     public function doSomething(Request $request): string
     {
-        return $this->translatorBridge->trans(
+        return $this->translator->trans(
             $request, 
             'my.hello',
         );
     }
 }
+```
+
+### Passing parameters
+
+To pass parameters to your translation strings you need to 
+provide the `TranslatorBridge::trans` method an associative
+array of values.
+
+```php
+/**
+ * @var \Distantmagic\Resonance\TranslatorBridge $translator
+ */
+$translator->trans($request, 'my.greeting', [
+    'name' => 'Resonance',
+])
 ```
 
 ## Twig
@@ -76,5 +92,14 @@ You can use the `trans` filter. The code below outputs `Earth`:
 {{ 'my.planet.ours'|trans(request) }}
 ```
 
-You can learn more info about twig in it's documentation page: 
+### Passing parameters
+
+To provide parameters to the translation string, you have to pass an
+object with values to the `trans` filter.
+
+```twig
+{{ 'my.greeting'|trans(request, {name: 'Magic'}) }}
+```
+
+You can learn more info about twig in its documentation page: 
 {{docs/features/templating/twig/index}}.

--- a/src/TranslationException/MissingTranslationParameterException.php
+++ b/src/TranslationException/MissingTranslationParameterException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Distantmagic\Resonance\TranslationException;
+
+use Distantmagic\Resonance\TranslationException;
+
+class MissingTranslationParameterException extends TranslationException
+{
+    public function __construct(string $phrase, string $missing)
+    {
+        parent::__construct("Translation parameter [{$missing}] is missing for translation string: {$phrase}");
+    }
+}

--- a/src/TranslatorBridge.php
+++ b/src/TranslatorBridge.php
@@ -29,6 +29,9 @@ readonly class TranslatorBridge
         $this->labels = new Map();
     }
 
+    /**
+     * @param array<string, string> $parameters
+     */
     public function trans(Request $request, string $phrase, array $parameters = []): string
     {
         $language = $this->languageDetector->detectPrimaryLanguage($request);
@@ -49,6 +52,9 @@ readonly class TranslatorBridge
         );
     }
 
+    /**
+     * @param array<string, string> $parameters
+     */
     protected function fillParameters(string $phrase, array $parameters): string
     {
         if (! $this->labels->hasKey($phrase)) {
@@ -57,7 +63,7 @@ readonly class TranslatorBridge
             $this->labels->put($phrase, $labels);
         }
 
-        $labels ??= $this->labels->get($phrase);
+        $labels ??= $this->labels->get($phrase, new Vector);
 
         foreach ($labels as $label) {
             if (! isset($parameters[$label])) {
@@ -72,9 +78,12 @@ readonly class TranslatorBridge
         return $phrase;
     }
 
+    /**
+     * @return array<int, string>
+     */
     protected function resolveLabels(string $phrase): array
     {
-        preg_match_all('/:([a-zA-Z]+)/m', $phrase, $matches);
+        preg_match_all('/:([a-zA-Z_]+)/m', $phrase, $matches);
 
         [1 => $labels] = $matches;
 

--- a/src/TranslatorBridge.php
+++ b/src/TranslatorBridge.php
@@ -63,9 +63,10 @@ readonly class TranslatorBridge
             $this->labels->put($phrase, $labels);
         }
 
+        /** @var Vector<string>|null $labels */
         $labels ??= $this->labels->get($phrase, new Vector);
 
-        foreach ($labels as $label) {
+        foreach ($labels ?? [] as $label) {
             if (! isset($parameters[$label])) {
                 throw new MissingTranslationParameterException($phrase, $label);
             }

--- a/src/TwigFilterTrans.php
+++ b/src/TwigFilterTrans.php
@@ -12,6 +12,9 @@ readonly class TwigFilterTrans
 {
     public function __construct(private TranslatorBridge $translatorBridge) {}
 
+    /**
+     * @param array<string, string> $parameters
+     */
     public function __invoke(string $message, Request $request, array $parameters = []): string
     {
         return $this->translatorBridge->trans($request, $message, $parameters);

--- a/src/TwigFilterTrans.php
+++ b/src/TwigFilterTrans.php
@@ -12,8 +12,8 @@ readonly class TwigFilterTrans
 {
     public function __construct(private TranslatorBridge $translatorBridge) {}
 
-    public function __invoke(string $message, Request $request): string
+    public function __invoke(string $message, Request $request, array $parameters = []): string
     {
-        return $this->translatorBridge->trans($request, $message);
+        return $this->translatorBridge->trans($request, $message, $parameters);
     }
 }


### PR DESCRIPTION
This PR adds the ability to pass parameters to your translation strings. It does this by replacing `:parameter` with a value passed to the `TranslatorBridge::trans` method via an array. 
```ini
# app/lang/en/website.ini
greeting = "Hello :name! I hope you are doing well on this fine :day."
```
```php
$this->translator->trans($request, 'greeting', [
    'name' => 'David', 'day' => 'Wednesday',
]);
```
The regex that matches all the `:label`s matches `:[a-zA-Z_]+`.